### PR TITLE
OperationManager 第二个构造器 configuration 初始化

### DIFF
--- a/src/main/java/com/qiniu/processing/OperationManager.java
+++ b/src/main/java/com/qiniu/processing/OperationManager.java
@@ -49,6 +49,7 @@ public final class OperationManager {
     public OperationManager(Auth auth, Client client) {
         this.auth = auth;
         this.client = client;
+        this.configuration = new Configuration();
     }
 
     /**


### PR DESCRIPTION
update OperationManager second constructor, because it has not init configuration so that NullPointerException will happen ifwhen the configuration be used.