### PR TITLE
UploadManager 第二个构造器 configuration 初始化

### DIFF
--- a/src/main/java/com/qiniu/storage/UploadManager.java
+++ b/src/main/java/com/qiniu/storage/UploadManager.java
@@ -44,6 +44,7 @@ public final class UploadManager {
     }
 
     public UploadManager(Client client, Recorder recorder) {
+        configuration = new Configuration();
         this.client = client;
         this.recorder = recorder;
     }

--- a/src/main/java/com/qiniu/storage/UploadManager.java
+++ b/src/main/java/com/qiniu/storage/UploadManager.java
@@ -44,9 +44,9 @@ public final class UploadManager {
     }
 
     public UploadManager(Client client, Recorder recorder) {
-        configuration = new Configuration();
         this.client = client;
         this.recorder = recorder;
+        configuration = new Configuration();
     }
 
     private static void checkArgs(final String key, byte[] data, File f, String token) {


### PR DESCRIPTION
update UploadManager second constructor, because it has not init configuration so that NullPointerException will happen ifwhen the configuration be used.