### PR TITLE
okhttp 3.11.0 to 3.14.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: java
 
+jdk:
+  - oraclejdk8
+  - oraclejdk
+
 env:
   global:
     - QINIU_ACCESS_KEY=vHg2e7nOh7Jsucv2Azr5FH6omPgX22zoJRWa0FN5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: java
 
-jdk:
-  - oraclejdk8
-  - oraclejdk
-
 env:
   global:
     - QINIU_ACCESS_KEY=vHg2e7nOh7Jsucv2Azr5FH6omPgX22zoJRWa0FN5

--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,10 @@ dependencies {
 }
 
 
-task getHomeDir << {
-    println gradle.gradleHomeDir
+task getHomeDir {
+    doLast {
+        println gradle.gradleHomeDir
+    }
 }
 
 apply plugin: 'checkstyle'

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.11.0'
+    compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.14.2'
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
     testCompile group: 'com.qiniu', name: 'happy-dns-java', version: '0.1.6'
     testCompile group: 'junit', name: 'junit', version: '4.12'

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -26,18 +26,16 @@
         <property name="message" value="Space needed around ':' character."/>
     </module>
 
-    <module name="SuppressionCommentFilter">
-    </module>
 
     <module name="TreeWalker">
-        <module name="FileContentsHolder"/>
+        <module name="SuppressionCommentFilter" />
         <!-- Checks for Javadoc comments.                     -->
         <!-- See http://checkstyle.sf.net/config_javadoc.html -->
         <!--module name="JavadocMethod"/-->
         <!--module name="JavadocType"/-->
         <!--module name="JavadocVariable"/-->
         <module name="JavadocStyle">
-            <property name="checkFirstSentence" value="false"/>
+            <property name="checkFirstSentence" value="false" />
         </module>
 
 
@@ -113,9 +111,6 @@
         <!--module name="InnerAssignment"/-->
         <!--module name="MagicNumber"/-->
         <!--module name="MissingSwitchDefault"/-->
-        <module name="RedundantThrows">
-            <property name="suppressLoadErrors" value="true"/>
-        </module>
         <module name="SimplifyBooleanExpression"/>
         <module name="SimplifyBooleanReturn"/>
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip

--- a/src/main/java/com/qiniu/storage/FixBlockUploader.java
+++ b/src/main/java/com/qiniu/storage/FixBlockUploader.java
@@ -730,7 +730,7 @@ public class FixBlockUploader {
         long alreadyReadSize = 0;
         Lock lock;
 
-        public FileBlockData(int blockDataSize, File file) throws IOException {
+        FileBlockData(int blockDataSize, File file) throws IOException {
             super(blockDataSize);
             fis = new RandomAccessFile(file, "r");
             totalLength = file.length();
@@ -820,15 +820,15 @@ public class FixBlockUploader {
 
         long alreadyReadSize = 0;
 
-        public InputStreamBlockData(int blockDataSize, InputStream is, long totalLength) {
+        InputStreamBlockData(int blockDataSize, InputStream is, long totalLength) {
             this(blockDataSize, is, totalLength, true);
         }
 
-        public InputStreamBlockData(int blockDataSize, InputStream is, long totalLength, boolean closedAfterUpload) {
+        InputStreamBlockData(int blockDataSize, InputStream is, long totalLength, boolean closedAfterUpload) {
             this(blockDataSize, is, totalLength, closedAfterUpload, false, "");
         }
 
-        public InputStreamBlockData(int blockDataSize, InputStream is, long totalLength, boolean closedAfterUpload,
+        InputStreamBlockData(int blockDataSize, InputStream is, long totalLength, boolean closedAfterUpload,
                                     boolean repeatable, String contentUUID) {
             super(blockDataSize);
             this.is = is;
@@ -929,7 +929,7 @@ public class FixBlockUploader {
     static class StaticToken implements Token {
         String token;
 
-        public StaticToken(String token) {
+        StaticToken(String token) {
             this.token = token;
         }
 

--- a/src/main/java/com/qiniu/storage/RegionReqInfo.java
+++ b/src/main/java/com/qiniu/storage/RegionReqInfo.java
@@ -25,7 +25,7 @@ class RegionReqInfo {
         }
     }
 
-    public RegionReqInfo(String accessKey, String bucket) {
+    RegionReqInfo(String accessKey, String bucket) {
         this.accessKey = accessKey;
         this.bucket = bucket;
     }

--- a/src/main/java/com/qiniu/util/IOUtils.java
+++ b/src/main/java/com/qiniu/util/IOUtils.java
@@ -21,7 +21,7 @@ public class IOUtils {
      * @throws IOException
      */
     public static byte[] toByteArray(final InputStream input) throws IOException {
-        try (final ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+        try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
             byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
             int n;
             while (-1 != (n = input.read(buffer))) {

--- a/src/test/java/com/qiniu/storage/FixBlockUploaderWithRecorderTest.java
+++ b/src/test/java/com/qiniu/storage/FixBlockUploaderWithRecorderTest.java
@@ -284,7 +284,7 @@ public class FixBlockUploaderWithRecorderTest {
         Recorder recorder;
         String recordFileKey;
 
-        public UploadRecordHelper(Recorder recorder, String bucket, String base64Key,
+        UploadRecordHelper(Recorder recorder, String bucket, String base64Key,
                                   String contentUUID, String uploaderSUID) {
             if (recorder != null) {
                 this.recorder = recorder;

--- a/src/test/java/test/com/qiniu/processing/PfopTest.java
+++ b/src/test/java/test/com/qiniu/processing/PfopTest.java
@@ -9,6 +9,7 @@ import com.qiniu.util.StringUtils;
 import com.qiniu.util.UrlSafeBase64;
 import org.junit.Assert;
 import org.junit.Test;
+import test.com.qiniu.ResCode;
 import test.com.qiniu.TestConfig;
 
 import java.util.HashMap;
@@ -74,7 +75,7 @@ public class PfopTest {
             OperationStatus status = operationManager.prefop(jobid);
             Assert.assertEquals(0, status.code);
         } catch (QiniuException ex) {
-            Assert.assertEquals(612, ex.code());
+            Assert.assertTrue(ResCode.find(ex.code(), ResCode.getPossibleResCode(612)));
         }
     }
 

--- a/src/test/java/test/com/qiniu/storage/FormUploadTest.java
+++ b/src/test/java/test/com/qiniu/storage/FormUploadTest.java
@@ -297,7 +297,7 @@ public class FormUploadTest {
             try {
                 f = TempFile.createFile(1);
                 File f1 = TempFile.createFile(1);
-                f = new File(f1.getParentFile(),"_试一个中文看下效果_" + f1.getName());
+                f = new File(f1.getParentFile(), "_试一个中文看下效果_" + f1.getName());
                 f1.renameTo(f);
             } catch (IOException e) {
                 e.printStackTrace();

--- a/src/test/java/test/com/qiniu/storage/RecordUploadTest.java
+++ b/src/test/java/test/com/qiniu/storage/RecordUploadTest.java
@@ -255,7 +255,7 @@ public class RecordUploadTest {
         private final String token;
         ResumeUploader uploader = null;
 
-        public Up(File file, String key, String token) {
+        Up(File file, String key, String token) {
             this.file = file;
             this.key = key;
             this.token = token;

--- a/src/test/java/test/com/qiniu/util/JsonTest.java
+++ b/src/test/java/test/com/qiniu/util/JsonTest.java
@@ -24,7 +24,7 @@ public class JsonTest {
         private String emailAddress;
         transient String s1;
         transient int i1;
-        public User(String name, int age) {
+        User(String name, int age) {
             this.name = name;
             this.age = age;
 //            this.emailAddress = emailAddress;


### PR DESCRIPTION
https://github.com/square/okhttp/blob/master/CHANGELOG.md

Version 3.13.0
2019-02-04
This release bumps our minimum requirements to Java 8+ or Android 5+.
The OkHttp 3.12.x branch will be our long-term branch for Android 2.3+ (API level 9+) and Java 7+.
Fix: Permit multipart file names to contain non-ASCII characters.

Version 3.12.3
2019-05-07
Fix: Permit multipart file names to contain non-ASCII characters.


3.12.3     or   3.14.2 ?