### PR TITLE
20200403 by panyuan:add 归档存储

### DIFF
--- a/src/main/java/com/qiniu/common/Constants.java
+++ b/src/main/java/com/qiniu/common/Constants.java
@@ -9,7 +9,7 @@ public final class Constants {
     /**
      * 版本号
      */
-    public static final String VERSION = "7.2.28";
+    public static final String VERSION = "7.2.29";
     /**
      * 块大小，不能改变
      */

--- a/src/main/java/com/qiniu/http/Client.java
+++ b/src/main/java/com/qiniu/http/Client.java
@@ -185,7 +185,8 @@ public final class Client {
             MediaType t = MediaType.parse(contentType);
             rbody = RequestBody.create(t, body);
         } else {
-            rbody = RequestBody.create(null, new byte[0]);
+            MediaType t = MediaType.parse(contentType);
+            rbody = RequestBody.create(t, new byte[0]);
         }
         return post(url, rbody, headers);
     }
@@ -202,6 +203,7 @@ public final class Client {
             MediaType t = MediaType.parse(contentType);
             rbody = RequestBody.create(t, body, offset, size);
         } else {
+            MediaType t = MediaType.parse(contentType);
             rbody = RequestBody.create(null, new byte[0]);
         }
         return put(url, rbody, headers);
@@ -214,6 +216,7 @@ public final class Client {
             MediaType t = MediaType.parse(contentType);
             rbody = create(t, body, offset, size);
         } else {
+            MediaType t = MediaType.parse(contentType);
             rbody = RequestBody.create(null, new byte[0]);
         }
         return post(url, rbody, headers);
@@ -297,6 +300,7 @@ public final class Client {
             MediaType t = MediaType.parse(contentType);
             rbody = RequestBody.create(t, body);
         } else {
+            MediaType t = MediaType.parse(contentType);
             rbody = RequestBody.create(null, new byte[0]);
         }
         return patch(url, rbody, headers);
@@ -309,6 +313,7 @@ public final class Client {
             MediaType t = MediaType.parse(contentType);
             rbody = create(t, body, offset, size);
         } else {
+            MediaType t = MediaType.parse(contentType);
             rbody = RequestBody.create(null, new byte[0]);
         }
         return patch(url, rbody, headers);
@@ -385,6 +390,7 @@ public final class Client {
             MediaType t = MediaType.parse(contentType);
             rbody = create(t, body, offset, size);
         } else {
+            MediaType t = MediaType.parse(contentType);
             rbody = RequestBody.create(null, new byte[0]);
         }
 

--- a/src/main/java/com/qiniu/storage/BucketManager.java
+++ b/src/main/java/com/qiniu/storage/BucketManager.java
@@ -331,7 +331,7 @@ public final class BucketManager {
      *
      * @param bucket 空间名称
      * @param key    文件名称
-     * @param type   type=0 表示普通存储，type=1 表示低频存存储
+     * @param type   type=0 表示普通存储，type=1 表示低频存存储, type=2 表示归档存储
      * @throws QiniuException
      */
     public Response changeType(String bucket, String key, StorageType type)
@@ -339,6 +339,24 @@ public final class BucketManager {
         String resource = encodedEntry(bucket, key);
         String path = String.format("/chtype/%s/type/%d", resource, type.ordinal());
         return rsPost(bucket, path, null);
+    }
+    
+    /**
+     * 解冻归档存储
+     * 文档：https://developer.qiniu.com/kodo/api/6380/restore-archive
+     * 
+     * @param bucket    空间名称
+     * @param key   文件名称
+     * @param freezeAfterDays   解冻有效时长，取值范围 1～7
+     * @return
+     */
+    public Response restoreArchive(String bucket, String key, int freezeAfterDays) 
+            throws QiniuException {
+        String resource = encodedEntry(bucket, key);
+        String path = String.format("/restoreAr/%s/freezeAfterDays/%s", resource, Integer.toString(freezeAfterDays));
+        String requestUrl = configHelper.rsHost(auth.accessKey, bucket) + path;
+        return client.post(requestUrl, null,
+                auth.authorizationV2(requestUrl, "POST", null, "application/json"), Client.JsonMime);
     }
 
     /**

--- a/src/main/java/com/qiniu/storage/model/StorageType.java
+++ b/src/main/java/com/qiniu/storage/model/StorageType.java
@@ -11,5 +11,9 @@ public enum StorageType {
     /**
      * 低频存储
      */
-    INFREQUENCY
+    INFREQUENCY,
+    /**
+     * 归档存储
+     */
+    Archive
 }

--- a/src/test/java/test/com/qiniu/CdnTest.java
+++ b/src/test/java/test/com/qiniu/CdnTest.java
@@ -52,7 +52,7 @@ public class CdnTest {
     /**
      * 测试刷新，只检查是否返回200
      */
-    //@Test
+    @Test
     public void testRefresh() {
         if (TestConfig.isTravis()) {
             return;
@@ -73,7 +73,7 @@ public class CdnTest {
     /**
      * 测试预取，只检测是否返回200
      */
-    //@Test
+    @Test
     public void testPrefetch() {
         CdnManager c = new CdnManager(TestConfig.testAuth);
         CdnResult.PrefetchResult r;
@@ -140,7 +140,7 @@ public class CdnTest {
      * 测试获取CDN域名访问日志的下载链接
      * 检测日志信息列表长度是否>=0
      */
-    //@Test
+    @Test
     public void testGetCdnLogList() {
         if (TestConfig.isTravis()) {
             return;
@@ -169,7 +169,7 @@ public class CdnTest {
      * 检测signedUrl3是否返回403
      * 检测signedUrl3与预期结果是否一致
      */
-    //@Test
+    @Test
     public void testCreateTimestampAntiLeechUrlSimple() {
         if (TestConfig.isTravis()) {
             return;
@@ -181,14 +181,12 @@ public class CdnTest {
         StringMap queryStringMap = new StringMap();
         queryStringMap.put("qiniu", "七牛");
         queryStringMap.put("test", "Test");
-        String encryptKey1 = "10992a8a688900b89ab9f58a6899cb8bb1b924ab";
-        String encryptKey2 = "64b89c989cb97cbb6a9b6c9a4ca93498b69974ab";
+        String encryptKey1 = "908b9cbbbc88028b50b8e8a88baa879bf1b8a788";
+        String encryptKey2 = "d799eba9ff99ea88cfb8acbbf8b82898208afbb8";
         long deadline1 = System.currentTimeMillis() / 1000 + 3600;
         long deadline2 = deadline1;
-        long deadline3 = 1551966091; // 2019-03-07 21:41:31 +0800 CST
-        String testUrl_z0_timeStamp_outdate =
-                "http://javasdk-timestamp.peterpy.cn/do_not_delete/1.png?"
-                        + "sign=50d05540eea4ea8ab905b57006edef7a&t=5c811f8b";
+        long deadline3 = 1485893946; // 2017-02-01 04:19:06 +0800 CST
+        String testUrl_z0_timeStamp_outdate = "http://javasdk-timestamp.peterpy.cn/do_not_delete/1.png?sign=14f48f829b78d5c9a34eb77e9a13f1b6&t=5890f13a";
         try {
             URL url = new URL(TestConfig.testUrl_z0_timeStamp);
             Assert.assertEquals(msg, 403, getResponse(url.toString()).statusCode);


### PR DESCRIPTION
1. BucketManager 下增加方法 restoreArchive（解冻归档存储）；新增 testRestoreArchive
2. Client 下 当不满足 body != null && body.length > 0 时，也将 contentType 加入到 requestBody 中去，是为了解决 POST QiniuToken 时，必须带 contentType 的需求
3. 优化 test 方法