### PR TITLE
LINK-1682  update qvs-java-sdk

### DIFF
--- a/src/main/java/com/qiniu/http/Client.java
+++ b/src/main/java/com/qiniu/http/Client.java
@@ -160,6 +160,23 @@ public final class Client {
         return send(requestBuilder, headers);
     }
 
+    public Response delete(String url, RequestBody body, StringMap headers) throws QiniuException {
+        Request.Builder requestBuilder = new Request.Builder().delete(body).url(url);
+        return send(requestBuilder, headers);
+    }
+
+    public Response delete(String url, byte[] body, StringMap headers, String contentType) throws QiniuException {
+        RequestBody rbody;
+        if (body != null && body.length > 0) {
+            MediaType t = MediaType.parse(contentType);
+            rbody = RequestBody.create(t, body);
+        } else {
+            MediaType t = MediaType.parse(contentType);
+            rbody = RequestBody.create(t, new byte[0]);
+        }
+        return delete(url, rbody, headers);
+    }
+
     public Response post(String url, byte[] body, StringMap headers) throws QiniuException {
         return post(url, body, headers, DefaultMime);
     }

--- a/src/main/java/com/qiniu/qvs/DeviceManager.java
+++ b/src/main/java/com/qiniu/qvs/DeviceManager.java
@@ -111,4 +111,38 @@ public class DeviceManager {
         return QvsResponse.post(url, params, client, auth);
     }
 
+    /*
+     * 同步设备通道
+     */
+    public Response fetchCatalog(String namespaceId, String gbId) throws QiniuException {
+        String url = String.format("%s/v1/namespaces/%s/devices/%s/catalog/fetch", apiServer, namespaceId, gbId);
+        return QvsResponse.post(url, new StringMap(), client, auth);
+    }
+
+    /*
+     * 查询通道详情
+     */
+    public Response queryChannel(String namespaceId, String gbId, String channelId) throws QiniuException {
+        String url = String.format("%s/v1/namespaces/%s/devices/%s/channels/%s", apiServer, namespaceId, gbId, channelId);
+        return QvsResponse.get(url, client, auth);
+    }
+
+    /*
+     * 删除通道
+     */
+    public Response deleteChannel(String namespaceId, String gbId, String channelId) throws QiniuException {
+        String url = String.format("%s/v1/namespaces/%s/devices/%s/channels/%s", apiServer, namespaceId, gbId, channelId);
+        return QvsResponse.delete(url, client, auth);
+    }
+
+    /*
+     * 查询本地录像列表
+     * 普通设备chId可以忽略, 置为空即可
+     */
+    public Response queryGBRecordHistories(String namespaceId, String gbId, String channelId, int start, int end) throws QiniuException {
+        String url = String.format("%s/v1/namespaces/%s/devices/%s/recordhistories", apiServer, namespaceId, gbId);
+        StringMap map = new StringMap().put("start", start).put("end", end).putNotNull("chId", channelId);
+        url = UrlUtils.composeUrlWithQueries(url, map);
+        return QvsResponse.get(url, client, auth);
+    }
 }

--- a/src/main/java/com/qiniu/qvs/NameSpaceManager.java
+++ b/src/main/java/com/qiniu/qvs/NameSpaceManager.java
@@ -52,6 +52,7 @@ public class NameSpaceManager {
         params.putNotNull("urlMode", nameSpace.getUrlMode());
         params.putNotNull("zone", nameSpace.getZone());
         params.putNotNull("hlsLowLatency", nameSpace.isHlsLowLatency());
+        params.putNotNull("onDemandPull", nameSpace.isOnDemandPull());
 
         String url = String.format("%s/v1/namespaces", apiServer);
         return QvsResponse.post(url, params, client, auth);

--- a/src/main/java/com/qiniu/qvs/QvsResponse.java
+++ b/src/main/java/com/qiniu/qvs/QvsResponse.java
@@ -63,4 +63,21 @@ public final class QvsResponse {
         }
         return res;
     }
+
+    public static Response delete(String url, StringMap params, Client client, Auth auth) throws QiniuException {
+        byte[] body;
+        String contentType = null;
+        if (params == null) {
+            body = null;
+        } else {
+            contentType = Client.JsonMime;
+            body = Json.encode(params).getBytes(Constants.UTF_8);
+        }
+        StringMap headers = auth.authorizationV2(url, "DELETE", body, contentType);
+        Response res = client.delete(url, body, headers, Client.JsonMime);
+        if (!res.isOK()) {
+            throw new QiniuException(res);
+        }
+        return res;
+    }
 }

--- a/src/main/java/com/qiniu/qvs/RecordManager.java
+++ b/src/main/java/com/qiniu/qvs/RecordManager.java
@@ -1,0 +1,88 @@
+package com.qiniu.qvs;
+
+import com.qiniu.common.QiniuException;
+import com.qiniu.http.Client;
+import com.qiniu.http.Response;
+import com.qiniu.util.Auth;
+import com.qiniu.util.StringMap;
+
+public class RecordManager {
+    private final String apiServer;
+    private final Client client;
+    private final Auth auth;
+
+    public RecordManager(Auth auth) {
+        this(auth, "http://qvs.qiniuapi.com");
+    }
+
+    public RecordManager(Auth auth, String apiServer) {
+        this(auth, apiServer, new Client());
+    }
+
+    public RecordManager(Auth auth, String apiServer, Client client) {
+        this.auth = auth;
+        this.apiServer = apiServer;
+        this.client = client;
+    }
+
+    /*
+     * 启动按需录制
+     */
+    public Response startRecord(String namespaceId, String streamId) throws QiniuException {
+        String url = String.format("%s/v1/namespaces/%s/streams/%s/record/start", apiServer, namespaceId, streamId);
+        return QvsResponse.post(url, new StringMap(), client, auth);
+    }
+
+    /*
+     * 停止按需录制
+     */
+    public Response stopRecord(String namespaceId, String streamId) throws QiniuException {
+        String url = String.format("%s/v1/namespaces/%s/streams/%s/record/stop", apiServer, namespaceId, streamId);
+        return QvsResponse.post(url, new StringMap(), client, auth);
+    }
+
+    /*
+     * 删除录制片段
+     */
+    public Response deleteStreamRecordHistories(String namespaceId, String streamId, String[] files) throws QiniuException {
+        String url = String.format("%s/v1/namespaces/%s/streams/%s/recordhistories", apiServer, namespaceId, streamId);
+        StringMap params = new StringMap();
+        params.putNotNull("files", files);
+        return QvsResponse.delete(url, params, client, auth);
+    }
+
+    /*
+     * 录制视频片段合并
+     * 参数：
+     *      fname 保存的文件名(需要带上文件格式后缀),不指定系统会随机生成
+     *      format 保存的文件格式,可以为m3u8, mp4或者flv
+     *      start 查询开始时间(unix时间戳,单位为秒)
+     *      end 查询结束时间(unix时间戳,单位为秒)
+     *      deleteTs 在不生成m3u8格式文件时是否删除对应的ts文件
+     *      pipeline 数据处理的私有队列，不指定则使用公共队列
+     *      notifyUrl 保存成功回调通知地址，不指定则不通知
+     *      deleteAfterDays 文件过期时间,默认和录制模版中的设置保持一致
+     */
+    public Response recordClipsSaveas(String namespaceId, String streamId, String fname, String format, int start, int end, boolean deleteTs, String pipeline, String notifyUrl, int deleteAfterDays) throws QiniuException {
+        String url = String.format("%s/v1/namespaces/%s/streams/%s/saveas", apiServer, namespaceId, streamId);
+        StringMap params = new StringMap();
+        params.putNotNull("fname", fname);
+        params.putNotNull("format", format);
+        params.putNotNull("start", start);
+        params.putNotNull("end", end);
+        params.putNotNull("deleteTs", deleteTs);
+        params.putNotNull("pipeline", pipeline);
+        params.putNotNull("notifyUrl", notifyUrl);
+        params.putNotNull("deleteAfterDays", deleteAfterDays);
+
+        return QvsResponse.post(url, params, client, auth);
+    }
+
+    /*
+     * 录制回放
+     */
+    public Response recordsPlayback(String namespaceId, String streamId, int start, int end) throws QiniuException {
+        String url = String.format("%s/v1/namespaces/%s/streams/%s/records/playback.m3u8?start=%d&end=%d", apiServer, namespaceId, streamId, start, end);
+        return QvsResponse.get(url, client, auth);
+    }
+}

--- a/src/main/java/com/qiniu/qvs/StatsManager.java
+++ b/src/main/java/com/qiniu/qvs/StatsManager.java
@@ -1,0 +1,42 @@
+package com.qiniu.qvs;
+
+import com.qiniu.common.QiniuException;
+import com.qiniu.http.Client;
+import com.qiniu.http.Response;
+import com.qiniu.util.Auth;
+import com.qiniu.util.StringMap;
+import com.qiniu.util.UrlUtils;
+
+public class StatsManager {
+    private final String apiServer;
+    private final Client client;
+    private final Auth auth;
+
+    public StatsManager(Auth auth) {
+        this(auth, "http://qvs.qiniuapi.com");
+    }
+
+    public StatsManager(Auth auth, String apiServer) {
+        this(auth, apiServer, new Client());
+    }
+
+    public StatsManager(Auth auth, String apiServer, Client client) {
+        this.auth = auth;
+        this.apiServer = apiServer;
+        this.client = client;
+    }
+
+    public Response queryFlow(String namespaceId, String streamId, String tu, int start, int end) throws QiniuException {
+        String url = String.format("%s/v1/stats/flow", apiServer);
+        StringMap map = new StringMap().put("nsId", namespaceId).putNotNull("streamId", streamId).put("start", start).put("end", end).put("tu", tu);
+        url = UrlUtils.composeUrlWithQueries(url, map);
+        return QvsResponse.get(url, client, auth);
+    }
+
+    public Response queryBandwidth(String namespaceId, String streamId, String tu, int start, int end) throws QiniuException {
+        String url = String.format("%s/v1/stats/bandwidth", apiServer);
+        StringMap map = new StringMap().put("nsId", namespaceId).putNotNull("streamId", streamId).put("start", start).put("end", end).put("tu", tu);
+        url = UrlUtils.composeUrlWithQueries(url, map);
+        return QvsResponse.get(url, client, auth);
+    }
+}

--- a/src/main/java/com/qiniu/qvs/StreamManager.java
+++ b/src/main/java/com/qiniu/qvs/StreamManager.java
@@ -137,6 +137,15 @@ public class StreamManager {
     }
 
     // 查询录制记录
+    public Response queryStreamRecordHistories(String namespaceId, String streamId, int start, int end, int line, String marker) throws QiniuException {
+        String requestUrl = String.format("%s/v1/namespaces/%s/streams/%s/recordhistories", apiServer, namespaceId, streamId);
+        StringMap map = new StringMap().putNotNull("start", start).putNotNull("end", end)
+                .putNotNull("line", line).putNotEmpty("marker", marker);
+        requestUrl = UrlUtils.composeUrlWithQueries(requestUrl, map);
+        return QvsResponse.get(requestUrl, client, auth);
+    }
+
+    // 查询录制记录
     public Response queryStreamRecordHistories(String namespaceId, String streamId, int start, int end, int line, String marker, String format) throws QiniuException {
         String requestUrl = String.format("%s/v1/namespaces/%s/streams/%s/recordhistories", apiServer, namespaceId, streamId);
         StringMap map = new StringMap().putNotNull("start", start).putNotNull("end", end)

--- a/src/main/java/com/qiniu/qvs/StreamManager.java
+++ b/src/main/java/com/qiniu/qvs/StreamManager.java
@@ -137,10 +137,10 @@ public class StreamManager {
     }
 
     // 查询录制记录
-    public Response queryStreamRecordHistories(String namespaceId, String streamId, int start, int end, int line, String marker) throws QiniuException {
+    public Response queryStreamRecordHistories(String namespaceId, String streamId, int start, int end, int line, String marker, String format) throws QiniuException {
         String requestUrl = String.format("%s/v1/namespaces/%s/streams/%s/recordhistories", apiServer, namespaceId, streamId);
         StringMap map = new StringMap().putNotNull("start", start).putNotNull("end", end)
-                .putNotNull("line", line).putNotEmpty("marker", marker);
+                .putNotNull("line", line).putNotEmpty("marker", marker).putNotEmpty("format", format);
         requestUrl = UrlUtils.composeUrlWithQueries(requestUrl, map);
         return QvsResponse.get(requestUrl, client, auth);
     }
@@ -164,5 +164,22 @@ public class StreamManager {
     public Response stopStream(String namespaceId, String streamId) throws QiniuException {
         String url = String.format("%s/v1/namespaces/%s/streams/%s/stop", apiServer, namespaceId, streamId);
         return QvsResponse.post(url, new StringMap(), client, auth);
+    }
+
+    /*
+     * 按需截图
+     */
+    public Response ondemandSnap(String namespaceId, String streamId) throws QiniuException {
+        String url = String.format("%s/v1/namespaces/%s/streams/%s/snap", apiServer, namespaceId, streamId);
+        return QvsResponse.post(url, new StringMap(), client, auth);
+    }
+
+    /*
+     * 删除截图
+     */
+    public Response deleteSnapshots(String namespaceId, String streamId, String[] files) throws QiniuException {
+        String url = String.format("%s/v1/namespaces/%s/streams/%s/snapshots", apiServer, namespaceId, streamId);
+        StringMap params = new StringMap().putNotNull("files", files);
+        return QvsResponse.delete(url, params, client, auth);
     }
 }

--- a/src/main/java/com/qiniu/qvs/model/NameSpace.java
+++ b/src/main/java/com/qiniu/qvs/model/NameSpace.java
@@ -25,6 +25,7 @@ public class NameSpace {
     private int urlMode; // 推拉流地址计算方式，1:static, 2:dynamic
     private String zone; // 存储区域
     private boolean hlsLowLatency; // hls低延迟开关
+    private boolean onDemandPull; // 按需拉流开关
 
     public String getId() {
         return id;
@@ -192,6 +193,14 @@ public class NameSpace {
 
     public void setHlsLowLatency(boolean hlsLowLatency) {
         this.hlsLowLatency = hlsLowLatency;
+    }
+
+    public boolean isOnDemandPull() {
+        return onDemandPull;
+    }
+
+    public void setOnDemandPull(boolean onDemandPull) {
+        this.onDemandPull = onDemandPull;
     }
 
 }

--- a/src/main/java/com/qiniu/qvs/model/Template.java
+++ b/src/main/java/com/qiniu/qvs/model/Template.java
@@ -15,8 +15,10 @@ public class Template {
     private int recordInterval;    // 录制文件时长(单位为秒)
     private int snapInterval;    // 截图间隔(单位为秒)
     private String m3u8FileNameTemplate;    // m3u8文件命名格式
+    private String flvFileNameTemplate;     // flv文件命名格式
+    private String mp4FileNameTemplate;     // mp4文件命名格式
     private int recordType;      // 录制模式, 0（不录制）,1（实时录制）, 2（按需录制）
-    private int recordFileFormat; // 录制文件存储格式,取值：0（ts格式存储）
+    private int recordFileFormat; // 录制文件存储格式(多选), 范围：1(001)～7(111), 从左往右的三位二进制数分别代表MP4, FLV, M3U8; 0代表不选择该格式, 1代表选择;例如：2(010)代表选择FLV格式，6(110)代表选择MP4和FLV格式，1(001)代表选择M3U8格式，7(111)代表三种格式均选择
     //record/ts/${namespaceId}/${streamId}/${startMs}-${endMs}.ts
     private String tsFilenametemplate;
     //record/snap/${namespaceId}/${streamId}/${startMs}.jpg // 录制封面
@@ -211,4 +213,21 @@ public class Template {
     public void setM3u8FileNameTemplate(String m3u8FileNameTemplate) {
         this.m3u8FileNameTemplate = m3u8FileNameTemplate;
     }
+
+    public String getFlvFileNameTemplate() {
+        return flvFileNameTemplate;
+    }
+
+    public void setFlvFileNameTemplate(String flvFileNameTemplate) {
+        this.flvFileNameTemplate = flvFileNameTemplate;
+    }
+
+    public String getMp4FileNameTemplate() {
+        return mp4FileNameTemplate;
+    }
+
+    public void setMp4FileNameTemplate(String mp4FileNameTemplate) {
+        this.mp4FileNameTemplate = mp4FileNameTemplate;
+    }
+
 }

--- a/src/test/java/test/com/qiniu/qvs/DeviceManagerTest.java
+++ b/src/test/java/test/com/qiniu/qvs/DeviceManagerTest.java
@@ -143,4 +143,49 @@ public class DeviceManagerTest {
             }
         }
     }
+
+    @Test
+    public void testFetchCatalog() {
+        try {
+            res = deviceManager.fetchCatalog("2xenzw5o81ods", "31011500991320000356");
+            Assert.assertNotNull(res);
+            System.out.println(res.bodyString());
+        } catch (QiniuException e) {
+            e.printStackTrace();
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+    }
+
+    @Test
+    public void testQueryChannel() {
+        try {
+            res = deviceManager.queryChannel("3nm4x0vyz7xlu", "31011500991180000270", "34020000001310000020");
+            Assert.assertNotNull(res);
+            System.out.println(res.bodyString());
+        } catch (QiniuException e) {
+            e.printStackTrace();
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+    }
+
+    @Test
+    public void testQueryGBRecordHistories() {
+        try {
+            res = deviceManager.queryGBRecordHistories("3nm4x0vyz7xlu", "31011500991180000270", "34020000001310000020", 1604817540, 1604903940);
+            Assert.assertNotNull(res);
+            System.out.println(res.bodyString());
+        } catch (QiniuException e) {
+            e.printStackTrace();
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+    }
 }

--- a/src/test/java/test/com/qiniu/qvs/RecordTest.java
+++ b/src/test/java/test/com/qiniu/qvs/RecordTest.java
@@ -1,0 +1,79 @@
+package test.com.qiniu.qvs;
+
+import com.qiniu.common.QiniuException;
+import com.qiniu.http.Response;
+import com.qiniu.qvs.RecordManager;
+import com.qiniu.util.Auth;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import test.com.qiniu.TestConfig;
+
+public class RecordTest {
+    Auth auth = TestConfig.testAuth;
+    private RecordManager recordManager;
+    private Response res = null;
+    private Response res2 = null;
+    private String namespaceId = "2xenzw5o81ods";
+    private String streamId = "31011500991320000356";
+    private String format = "m3u8";
+    private int start = 1605254612;
+    private int end = 1605255300;
+
+    @Before
+    public void setUp() throws Exception {
+        this.recordManager = new RecordManager(auth);
+    }
+
+    @Test
+    public void testOndemandRecord() throws Exception {
+        try {
+            res = recordManager.startRecord(namespaceId, streamId);
+            Assert.assertNotNull(res);
+            System.out.println(res.bodyString());
+            Thread.sleep(1000*60);
+            res2 = recordManager.stopRecord(namespaceId, streamId);
+            Assert.assertNotNull(res2);
+            System.out.println(res2.bodyString());
+        } catch (QiniuException e) {
+            e.printStackTrace();
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+            if (res2 != null) {
+                res2.close();
+            }
+        }
+    }
+
+    @Test
+    public void testRecordClipsSaveas() {
+        try {
+            res = recordManager.recordClipsSaveas(namespaceId, streamId, "", format, start, end, false, "", "", 0);
+            Assert.assertNotNull(res);
+            System.out.println(res.bodyString());
+        } catch (QiniuException e) {
+            e.printStackTrace();
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+    }
+
+    @Test
+    public void testRecordsPlayback() {
+        try {
+            res = recordManager.recordsPlayback(namespaceId, streamId, start, end);
+            Assert.assertNotNull(res);
+            System.out.println(res.bodyString());
+        } catch (QiniuException e) {
+            e.printStackTrace();
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+    }
+}

--- a/src/test/java/test/com/qiniu/qvs/StatsTest.java
+++ b/src/test/java/test/com/qiniu/qvs/StatsTest.java
@@ -1,0 +1,56 @@
+package test.com.qiniu.qvs;
+
+import com.qiniu.common.QiniuException;
+import com.qiniu.http.Response;
+import com.qiniu.qvs.StatsManager;
+import com.qiniu.util.Auth;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import test.com.qiniu.TestConfig;
+
+public class StatsTest {
+    Auth auth = TestConfig.testAuth;
+    private StatsManager statsManager;
+    private Response res = null;
+    private String namespaceId = "";
+    private String streamId = "";
+    private String tu = "5min";
+    private int start = 20200901;
+    private int end = 20200902;
+
+    @Before
+    public void setUp() throws Exception {
+        this.statsManager = new StatsManager(auth);
+    }
+
+    @Test
+    public void testQueryFlow() {
+        try {
+            res = statsManager.queryFlow(namespaceId, streamId, tu, start, end);
+            Assert.assertNotNull(res);
+            System.out.println(res.bodyString());
+        } catch (QiniuException e) {
+            e.printStackTrace();
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+    }
+
+    @Test
+    public void testQueryBandwidth() {
+        try {
+            res = statsManager.queryBandwidth(namespaceId, streamId, tu, start, end);
+            Assert.assertNotNull(res);
+            System.out.println(res.bodyString());
+        } catch (QiniuException e) {
+            e.printStackTrace();
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+    }
+}

--- a/src/test/java/test/com/qiniu/qvs/StreamTest.java
+++ b/src/test/java/test/com/qiniu/qvs/StreamTest.java
@@ -25,6 +25,7 @@ public class StreamTest {
     private int line = 1;
     private int qtype = 0;
     private String maker = "";
+    private String format = "";
 
     @Before
     public void setUp() throws Exception {
@@ -125,7 +126,7 @@ public class StreamTest {
     @Test
     public void testQueryStreamRecordHistories() {
         try {
-            res = streamManager.queryStreamRecordHistories(namespaceId, stream.getStreamID(), start, end, line, maker);
+            res = streamManager.queryStreamRecordHistories(namespaceId, stream.getStreamID(), start, end, line, maker, format);
             System.out.println(res.bodyString());
         } catch (QiniuException e) {
             e.printStackTrace();
@@ -220,4 +221,17 @@ public class StreamTest {
         }
     }
 
+    @Test
+    public void testOndemandSnap() {
+        try {
+            res = streamManager.ondemandSnap("2xenzw5o81ods", "31011500991320000356");
+            System.out.println(res.bodyString());
+        } catch (QiniuException e) {
+            e.printStackTrace();
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+    }
 }


### PR DESCRIPTION
本次升级qvs-java-sdk事项：
1.新增录制管理相关api
2.新增数据统计管理相关api
3.流管理api增加按需截图，删除截图
4.设备管理api增加通道管理，查询本地录像回放列表
5.空间增加ondemandPull字段，模板修改recordFileFormat字段说明，增加mp4，flv录制格式字段
6.增加带有body的http的delete请求
7.增加相关单元测试并测试通过
